### PR TITLE
fix: persist only if possible

### DIFF
--- a/src/commands/slim.yaml
+++ b/src/commands/slim.yaml
@@ -25,7 +25,18 @@ steps:
       name: Slim Docker image and generate profiles
       command: |
         slim build --copy-meta-artifacts . --target << parameters.image >>:<< parameters.tag >> --tag << parameters.output_image >>
+  - run:
+      name: Move AppArmor and Seccomp profiles if they exist
+      command: |
+        mkdir -p workspace
+        if [ -f "<< parameters.image >>-apparmor-profile" ]; then
+          mv "<< parameters.image >>-apparmor-profile" workspace/
+        fi
+        if [ -f "<< parameters.image >>-seccomp.json" ]; then
+          mv "<< parameters.image >>-seccomp.json" workspace/
+        fi
   - persist_to_workspace:
-      root: .
+      root: workspace
       paths:
         - << parameters.image >>-apparmor-profile
+        - << parameters.image >>-seccomp.json


### PR DESCRIPTION
Enhance the workflow by moving AppArmor and Seccomp profiles to a designated workspace before persisting, ensuring only relevant files are retained.