### PR TITLE
fix: non-existing file references in workspace persistence

### DIFF
--- a/src/commands/slim.yaml
+++ b/src/commands/slim.yaml
@@ -38,5 +38,4 @@ steps:
   - persist_to_workspace:
       root: workspace
       paths:
-        - << parameters.image >>-apparmor-profile
-        - << parameters.image >>-seccomp.json
+        - .


### PR DESCRIPTION
Remove specific file references in the workspace persistence step to ensure all files are included correctly.