### PR TITLE
Enable pushing built images to remote registry

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -28,12 +28,14 @@ jobs:
     steps:
       # Run your orb's commands to validate them.
       - slim-orb/slim:
-          images: "nginx,httpd"
-          tag: "latest"
+          images: "nginx,httpd"                 # Required: Comma-separated list of image names
+          tag: latest                           # Required: Tag to use for all input images
           # repo: ""                            # Optional: e.g. "myrepo/"
-          output_tag: "slim.latest"
-          setup_docker: true
+          output_tag: slim.latest               # Optional: e.g. "slim" or "slim.latest"
+          setup_docker: true                    # Optional: set to true to use remote Docker
           build_options: "--http-probe=false"   # Optional: additional SlimToolkit build options
+          # global_options: ""                  # Optional: additional global SlimToolkit options
+          # push_images: false                  # Optional: set to true to push images after build
 workflows:
   test-deploy:
     jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ orb.yml
 .DS_Store
 .vscode/launch.json
 workspace/*-apparmor-profile
-slim.report.json
+*.report.json
+creport.json

--- a/src/commands/slim.yaml
+++ b/src/commands/slim.yaml
@@ -33,6 +33,10 @@ parameters:
     type: string
     default: ""
     description: Additional global options for the SlimToolkit command (see https://github.com/slimtoolkit/slim?tab=readme-ov-file#usage-details)
+  push_images:
+    type: boolean
+    default: false
+    description: Whether to push the resulting images to the remote registry after building
 steps:
   - when:
       condition: << parameters.setup_docker >>
@@ -54,6 +58,7 @@ steps:
         OUTPUT_TAG: << parameters.output_tag >>
         BUILD_OPTIONS: << parameters.build_options >>
         GLOBAL_OPTIONS: << parameters.global_options >>
+        PUSH_IMAGES: << parameters.push_images >>
   - persist_to_workspace:
       root: workspace
       paths:

--- a/src/examples/example.yml
+++ b/src/examples/example.yml
@@ -9,9 +9,11 @@ usage:
     use-slim-orb:
       jobs:
         - slim-orb/slim:
-            images: "nginx,alpine"
-            tag: latest
-            repo: ""                # Optional: e.g. "myrepo/"
-            output_tag: slim.latest # Optional: e.g. "slim" or "slim.latest"
-            setup_docker: true      # Optional: set to true to use remote Docker
-            build_options: "--http-probe=false"       # Optional: additional SlimToolkit build options
+            images: "nginx,alpine"                # Required: Comma-separated list of image names
+            tag: latest                           # Required: Tag to use for all input images
+            repo: ""                              # Optional: e.g. "myrepo/"
+            output_tag: slim.latest               # Optional: e.g. "slim" or "slim.latest"
+            setup_docker: true                    # Optional: set to true to use remote Docker
+            build_options: "--http-probe=false"   # Optional: additional SlimToolkit build options
+            global_options: ""                    # Optional: additional global SlimToolkit options
+            push_images: false                    # Optional: set to true to push images after build

--- a/src/scripts/slim.py
+++ b/src/scripts/slim.py
@@ -33,6 +33,7 @@ def main():
     output_tag = os.environ.get("OUTPUT_TAG", "")
     build_options = os.environ.get("BUILD_OPTIONS", "")
     global_options = os.environ.get("GLOBAL_OPTIONS", "")
+    push_images = os.environ.get("PUSH_IMAGES", "false").lower() == "true"
 
     images_list = sanitize_and_validate(images, tag, repo, output_tag, build_options, global_options)
 
@@ -60,6 +61,9 @@ def main():
         for profile in [f"{img_name}-apparmor-profile", f"{img_name}-seccomp.json"]:
             if os.path.isfile(profile):
                 os.rename(profile, os.path.join("workspace", profile))
+        # Optionally push image
+        if push_images:
+            subprocess.run(["docker", "push", output_image], check=True)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Add an option to push resulting images to a remote registry after building. Update the configuration to include a `push_images` parameter and modify the main function to handle the image push operation.