### PR TITLE
Support boolean environment variable handling

### DIFF
--- a/src/scripts/slim.py
+++ b/src/scripts/slim.py
@@ -33,7 +33,7 @@ def main():
     output_tag = os.environ.get("OUTPUT_TAG", "")
     build_options = os.environ.get("BUILD_OPTIONS", "")
     global_options = os.environ.get("GLOBAL_OPTIONS", "")
-    push_images = os.environ.get("PUSH_IMAGES", "false").lower() == "true"
+    push_images = str(os.environ.get("PUSH_IMAGES", "false")).lower() == "true"
 
     images_list = sanitize_and_validate(images, tag, repo, output_tag, build_options, global_options)
 


### PR DESCRIPTION
Ensure the `PUSH_IMAGES` environment variable is correctly interpreted as a boolean by explicitly converting it to a string before comparison.